### PR TITLE
feat: add role enum to Prisma schema for user authorization

### DIFF
--- a/prisma/migrations/20250410074635_added_roleto_user/migration.sql
+++ b/prisma/migrations/20250410074635_added_roleto_user/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `passwod` on the `users` table. All the data in the column will be lost.
+  - Added the required column `password` to the `users` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `users` DROP COLUMN `passwod`,
+    ADD COLUMN `password` VARCHAR(191) NOT NULL,
+    ADD COLUMN `role` ENUM('ADMIN', 'USER') NOT NULL DEFAULT 'USER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,11 +13,17 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  ADMIN
+  USER
+}
+
 model User {
   id        Int      @id @default(autoincrement())
   name      String
   email     String   @unique
   password  String
+  role      Role     @default(USER)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION
Defined a Role enum in schema.prisma to support role-based access control.