### PR TITLE
fix: add missing 'city' field to AddressSchema validation

### DIFF
--- a/prisma/migrations/20250417224728_enforced_pincode_to_be_six_digits/migration.sql
+++ b/prisma/migrations/20250417224728_enforced_pincode_to_be_six_digits/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `pinCode` on the `addresses` table. The data in that column could be lost. The data in that column will be cast from `VarChar(191)` to `VarChar(6)`.
+
+*/
+-- AlterTable
+ALTER TABLE `addresses` MODIFY `pinCode` VARCHAR(6) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,7 +37,7 @@ model Address {
   lineTwo   String?
   city      String
   country   String
-  pinCode   String // <-- Add this line
+  pinCode   String   @db.VarChar(6) // Enforce 6 characters in the database
   userId    Int
   user      User     @relation(fields: [userId], references: [id])
   createdAt DateTime @default(now())

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -6,6 +6,10 @@ import { ErrorCodes } from '../exceptions/root';
 
 export const addAddress = async (req: Request, res: Response) => {
   AddressSchema.parse(req.body);
+  // Check if req.user is defined
+  if (!req.user) {
+    return res.status(401).json({ message: 'User not authenticated' });
+  }
 
   const address = await prismaClient.address.create({
     data: {
@@ -29,6 +33,10 @@ export const deleteAddress = async (req: Request, res: Response) => {
 };
 
 export const listAddress = async (req: Request, res: Response) => {
+  // Check if req.user is defined
+  if (!req.user) {
+    return res.status(401).json({ message: 'User not authenticated' });
+  }
   const address = await prismaClient.address.findMany({
     where: {
       userId: req.user.id,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,10 @@
 import { Router } from 'express';
 import authRoutes from './auth';
 import productRoutes from './product';
+import userRoutes from './users';
 const rootRouter: Router = Router();
 rootRouter.use('/auth', authRoutes);
 rootRouter.use('/product', productRoutes);
+rootRouter.use('/address', userRoutes);
+
 export default rootRouter;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -5,8 +5,8 @@ import adminMiddleWare from '../middlewares/admin';
 import { addAddress, deleteAddress, listAddress } from '../controllers/users';
 
 const userRoutes: Router = Router();
-userRoutes.post('/address', [authMiddleWare], errorHandler(addAddress));
-userRoutes.delete('/address/:id', [authMiddleWare], errorHandler(deleteAddress));
-userRoutes.get('/address', [authMiddleWare], errorHandler(listAddress));
+userRoutes.post('/', [authMiddleWare], errorHandler(addAddress));
+userRoutes.delete('/:id', [authMiddleWare], errorHandler(deleteAddress));
+userRoutes.get('/', [authMiddleWare], errorHandler(listAddress));
 
 export default userRoutes;

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -11,4 +11,5 @@ export const AddressSchema = z.object({
   lineTwo: z.string().nullable(),
   pinCode: z.string().length(6),
   country: z.string(),
+  city: z.string(),
 });


### PR DESCRIPTION
City field was missing from validation, causing Prisma errors during address creation.