### PR TITLE
feat(schema): add Order, OrderProduct, and orderEvent models with enums

### DIFF
--- a/prisma/migrations/20250425165253_create_ordertables/migration.sql
+++ b/prisma/migrations/20250425165253_create_ordertables/migration.sql
@@ -1,0 +1,46 @@
+-- CreateTable
+CREATE TABLE `orders` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NOT NULL,
+    `netAmount` DECIMAL(65, 30) NOT NULL,
+    `address` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updateAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `order_product` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `orderId` INTEGER NOT NULL,
+    `productId` INTEGER NOT NULL,
+    `quantity` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updateAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `order_events` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `orderId` INTEGER NOT NULL,
+    `status` ENUM('PENDING', 'ACCEPTED', 'OUT_FOR_DELIVERY', 'DELIVERED', 'CANCELLED') NOT NULL DEFAULT 'PENDING',
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updateAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `orders` ADD CONSTRAINT `orders_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `order_product` ADD CONSTRAINT `order_product_orderId_fkey` FOREIGN KEY (`orderId`) REFERENCES `orders`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `order_product` ADD CONSTRAINT `order_product_productId_fkey` FOREIGN KEY (`productId`) REFERENCES `product`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `order_events` ADD CONSTRAINT `order_events_orderId_fkey` FOREIGN KEY (`orderId`) REFERENCES `orders`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,14 @@ enum Role {
   USER
 }
 
+enum orderEventStatus {
+  PENDING
+  ACCEPTED
+  OUT_FOR_DELIVERY
+  DELIVERED
+  CANCELLED
+}
+
 model User {
   id                     Int        @id @default(autoincrement())
   name                   String
@@ -30,6 +38,7 @@ model User {
   updatedAt              DateTime   @updatedAt
   addresses              Address[]
   CartItem               CartItem[]
+  Order                  Order[]
 
   @@map("users")
 }
@@ -50,14 +59,15 @@ model Address {
 }
 
 model Product {
-  id          Int        @id @default(autoincrement())
-  name        String
-  description String     @db.Text
-  price       Decimal
-  tags        String
-  createdAt   DateTime   @default(now())
-  updateAt    DateTime   @updatedAt
-  CartItem    CartItem[]
+  id           Int            @id @default(autoincrement())
+  name         String
+  description  String         @db.Text
+  price        Decimal
+  tags         String
+  createdAt    DateTime       @default(now())
+  updateAt     DateTime       @updatedAt
+  CartItem     CartItem[]
+  OrderProduct OrderProduct[]
 
   @@map("product")
 }
@@ -73,4 +83,43 @@ model CartItem {
   updateAt  DateTime @updatedAt
 
   @@map("cart_items")
+}
+
+model Order {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id])
+  netAmount Decimal
+  address   String
+  createdAt DateTime @default(now())
+  updateAt  DateTime @updatedAt
+
+  product    OrderProduct[]
+  orderEvent orderEvent[]
+
+  @@map("orders")
+}
+
+model OrderProduct {
+  id        Int      @id @default(autoincrement())
+  orderId   Int
+  order     Order    @relation(fields: [orderId], references: [id])
+  productId Int
+  product   Product  @relation(fields: [productId], references: [id])
+  quantity  Int
+  createdAt DateTime @default(now())
+  updateAt  DateTime @updatedAt
+
+  @@map("order_product")
+}
+
+model orderEvent {
+  id        Int              @id @default(autoincrement())
+  orderId   Int
+  order     Order            @relation(fields: [orderId], references: [id])
+  status    orderEventStatus @default(PENDING)
+  createdAt DateTime         @default(now())
+  updateAt  DateTime         @updatedAt
+
+  @@map("order_events")
 }

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -97,4 +97,3 @@ export const updateUser = async (req: Request, res: Response) => {
   res.json(updatedUser);
 };
 
-export const cartConroller = async (req: Request, res: Response) => {};


### PR DESCRIPTION
Introduced Order, OrderProduct, and orderEvent models to support order management

Added orderEventStatus enum to represent lifecycle states (PENDING to DELIVERED)

Set up relations for users, products, and order events for structured tracking