### PR TITLE
feat(order): implement order creation flow with cart sync and address…

### DIFF
--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -1,0 +1,79 @@
+import { Request, Response } from 'express';
+import { prismaClient } from '..';
+import { NotFoundExceptions } from '../exceptions/not-found';
+import { ErrorCodes } from '../exceptions/root';
+
+export const createOrder = async (req: Request, res: Response) => {
+  return await prismaClient.$transaction(async (tx) => {
+    const cartItems = await tx.cartItem.findMany({
+      where: {
+        userId: req.user.id,
+      },
+      include: {
+        product: true,
+      },
+    });
+    if (cartItems.length === 0) {
+      return res.json({ message: 'cart is empty' });
+    }
+
+    const price = cartItems.reduce((prev, current) => {
+      return prev + current.quantity * +current.product.price;
+    }, 0);
+
+    const defaultAddressId = req.user.defaultShippingAddress;
+
+    if (!defaultAddressId) {
+      throw new NotFoundExceptions(
+        'No default shipping address found.',
+        ErrorCodes.ADDRESS_NOT_FOUND
+      );
+    }
+
+    const address = await tx.address.findFirst({
+      where: {
+        id: defaultAddressId,
+      },
+    });
+
+    if (!address) {
+      throw new NotFoundExceptions('Shipping address not found.', ErrorCodes.ADDRESS_NOT_FOUND);
+    }
+
+    const order = await tx.order.create({
+      data: {
+        userId: req.user.id,
+        netAmount: price,
+        address: address.formattedAddress,
+        product: {
+          create: cartItems.map((cart) => {
+            return {
+              productId: cart.productId,
+              quantity: cart.quantity,
+            };
+          }),
+        },
+      },
+    });
+
+    const orderEvent = await tx.orderEvent.create({
+      data: {
+        orderId: order.id,
+      },
+    });
+
+    await tx.cartItem.deleteMany({
+      where: {
+        userId: req.user.id,
+      },
+    });
+
+    return res.json(order);
+  });
+};
+
+export const listOrders = async (req: Request, res: Response) => {};
+
+export const canceleOrder = async (req: Request, res: Response) => {};
+
+export const geteOrderById = async (req: Request, res: Response) => {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,26 @@ app.use('/api/v1/', rootRouter);
 
 export const prismaClient = new PrismaClient({
   log: ['query'],
+}).$extends({
+  result: {
+    address: {
+      formattedAddress: {
+        needs: {
+          lineOne: true,
+          lineTwo: true,
+          city: true,
+          country: true,
+          pinCode: true,
+        },
+        compute: (addr) => {
+          return `${addr.lineOne}, ${addr.lineTwo}, ${addr.city}, ${addr.country}-${addr.pinCode}`;
+        },
+      },
+    },
+  },
 });
 
 app.use(errorMiddleware);
 app.listen(PORT, () => {
-  console.log(`App runnning on port ${PORT}`);
+  console.log(`Server is running at http://localhost:${PORT}`);
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,10 +3,12 @@ import authRoutes from './auth';
 import productRoutes from './product';
 import userRoutes from './users';
 import cartRoutes from './cart';
+import orderRoutes from './orders';
 const rootRouter: Router = Router();
 rootRouter.use('/auth', authRoutes);
 rootRouter.use('/product', productRoutes);
 rootRouter.use('/address', userRoutes);
 rootRouter.use('/cart', cartRoutes);
+rootRouter.use('/order', orderRoutes);
 
 export default rootRouter;

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import authMiddleWare from '../middlewares/auth';
+import { errorHandler } from '../error-handler';
+import { canceleOrder, createOrder, geteOrderById, listOrders } from '../controllers/orders';
+
+const orderRoutes: Router = Router();
+
+orderRoutes.post('/', [authMiddleWare], errorHandler(createOrder));
+orderRoutes.get('/', [authMiddleWare], errorHandler(listOrders));
+orderRoutes.put('/:id/cancel', [authMiddleWare], errorHandler(canceleOrder));
+orderRoutes.get('/:id', [authMiddleWare], errorHandler(geteOrderById));
+export default orderRoutes;


### PR DESCRIPTION
Created createOrder controller:
→ Converts cart items into an order
→ Automatically includes formatted shipping address
→ Tracks initial order status with orderEvent
→ Clears cart after order creation

Extended Prisma to compute formattedAddress for clean delivery info
![index ts - ShopAPI - Visual Studio Code 4_30_2025 11_03_43 AM](https://github.com/user-attachments/assets/3606da5f-03ff-4da9-b87e-8b7351ecfb0a)

![index ts - ShopAPI - Visual Studio Code 4_30_2025 11_03_54 AM](https://github.com/user-attachments/assets/d1143e6e-0ea9-4e42-861a-a447091d441b)
