### PR TITLE
feat(admin): add order management and user-specific order endpoints

### DIFF
--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,12 +1,24 @@
 import { Router } from 'express';
 import authMiddleWare from '../middlewares/auth';
 import { errorHandler } from '../error-handler';
-import { cancelOrder, createOrder, geteOrderById, listOrders } from '../controllers/orders';
+import {
+  cancelOrder,
+  changeStatus,
+  createOrder,
+  geteOrderById,
+  listAllOrders,
+  listOrders,
+  listUsersOrders,
+} from '../controllers/orders';
+import adminMiddleWare from '../middlewares/admin';
 
 const orderRoutes: Router = Router();
 
 orderRoutes.post('/', [authMiddleWare], errorHandler(createOrder));
 orderRoutes.get('/', [authMiddleWare], errorHandler(listOrders));
 orderRoutes.put('/:id/cancel', [authMiddleWare], errorHandler(cancelOrder));
+orderRoutes.get('/index', [authMiddleWare], [adminMiddleWare], errorHandler(listAllOrders));
+orderRoutes.get('/:id/user', [authMiddleWare], [adminMiddleWare], errorHandler(listUsersOrders));
+orderRoutes.put('/:id/status', [authMiddleWare], [adminMiddleWare], errorHandler(changeStatus));
 orderRoutes.get('/:id', [authMiddleWare], errorHandler(geteOrderById));
 export default orderRoutes;


### PR DESCRIPTION
- Implemented `listAllOrders` with optional status filter and pagination (5 per page)
- Created `changeStatus` to update order status and log an associated order event
- Built `listUsersOrders` to fetch orders for a specific user, with optional status filter and pagination
- Added error handling for cases where no orders are found
- Enhanced responses with clear success messages and relevant data
